### PR TITLE
extract common parts of tcp and dns ig tracer

### DIFF
--- a/builder/Dockerfile.linux
+++ b/builder/Dockerfile.linux
@@ -17,6 +17,7 @@ RUN go mod download
 COPY . .
 
 RUN go build -buildvcs=false ./cmd/aks-periscope
+<<<<<<< HEAD
 
 # Add dependencies for building nsenter
 RUN apt-get update && \
@@ -29,6 +30,8 @@ RUN tar -xf v2.38.tar.gz && mv util-linux-2.38 util-linux
 WORKDIR /build/util-linux
 RUN ./autogen.sh && ./configure
 RUN make LDFLAGS="--static" nsenter
+=======
+>>>>>>> allow building in a container (without .git folder)
 
 # Runner
 FROM $BASE_IMAGE

--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -99,6 +99,8 @@ func run(osIdentifier utils.OSIdentifier, knownFilePaths *utils.KnownFilePaths, 
 		collector.NewSystemLogsCollector(osIdentifier, runtimeInfo),
 		collector.NewSystemPerfCollector(config, runtimeInfo),
 		collector.NewWindowsLogsCollector(osIdentifier, runtimeInfo, knownFilePaths, fileSystem, 10*time.Second, 20*time.Minute),
+		collector.NewInspektorGadgetDNSTraceCollector(osIdentifier, runtimeInfo, traceWaiter, containerCollectionOptions),
+		collector.NewInspektorGadgetTCPTraceCollector(osIdentifier, runtimeInfo, traceWaiter, containerCollectionOptions),
 	}
 	collectors = addOSSpecificCollectors(collectors, config, runtimeInfo)
 

--- a/pkg/collector/gadgets/inspektor_trace_common_linux.go
+++ b/pkg/collector/gadgets/inspektor_trace_common_linux.go
@@ -1,0 +1,89 @@
+package gadgets
+
+import (
+	"fmt"
+	"github.com/cilium/ebpf/rlimit"
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	"log"
+	"sync"
+	"time"
+)
+
+// IGTraceContainerCollector is a constructor.
+type IGTraceContainerCollector struct {
+	data                       *sync.Map
+	containerCollectionOptions []containercollection.ContainerCollectionOption
+}
+
+// NewIGTraceContainerCollector is a constructor.
+func NewIGTraceContainerCollector(
+	containerCollectionOptions []containercollection.ContainerCollectionOption) *IGTraceContainerCollector {
+	return &IGTraceContainerCollector{
+		data:                       &sync.Map{},
+		containerCollectionOptions: containerCollectionOptions,
+	}
+}
+
+func info(container *containercollection.Container) string {
+	if container == nil {
+		return time.Now().Format(time.RFC3339Nano)
+	}
+	return fmt.Sprintf("%s /namespaces/%s/pods/%s/containers/%s ", container.Namespace, container.Podname,
+		container.Name, time.Now().Format(time.RFC3339Nano))
+}
+
+func (collector *IGTraceContainerCollector) PublishEvent(
+	traceName string,
+	container *containercollection.Container,
+	eventDetails string) {
+
+	events, loaded := collector.data.LoadOrStore(traceName, map[string]string{info(container): eventDetails})
+	if loaded {
+		// hopefully nano is granular enough to avoid collisions
+		(events.(map[string]string))[info(container)] = eventDetails
+		collector.data.Store(traceName, events)
+	}
+}
+
+func (collector *IGTraceContainerCollector) InitContainerCollection() (*containercollection.ContainerCollection, error) {
+	// From https://www.inspektor-gadget.io/blog/2022/09/using-inspektor-gadget-from-golang-applications/
+	// In some kernel versions it's needed to bump the rlimits to use run BPF programs.
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("failed to remove memlock: %w", err)
+	}
+
+	// We want to trace events from all pods running on the node, not just the current process, aka aks-periscope.
+	// To do this we need to make use of a ContainerCollection, which can be initially populated
+	// with all the pod processes, and dynamically updated as pods are created and deleted.
+
+	//this is common to all gadgets to listen to container events
+
+	containerEventCallback := func(event containercollection.PubSubEvent) {
+		switch event.Type {
+		case containercollection.EventTypeAddContainer:
+			log.Printf("Container added: %q pid %d\n", event.Container.Name, event.Container.Pid)
+		case containercollection.EventTypeRemoveContainer:
+			log.Printf("Container removed: %q pid %d\n", event.Container.Name, event.Container.Pid)
+		}
+	}
+
+	// Use the supplied container collection options, but prepend the container event callback.
+	// The options are all functions that are executed when the container collection is initialized.
+	opts := append(
+		[]containercollection.ContainerCollectionOption{containercollection.WithPubSub(containerEventCallback)},
+		collector.containerCollectionOptions...,
+	)
+
+	// Initialize the container collection, receiver should close the container collection
+	containerCollection := &containercollection.ContainerCollection{}
+	if err := containerCollection.Initialize(opts...); err != nil {
+		return nil, fmt.Errorf("failed to initialize container collection: %w", err)
+	}
+
+	return containerCollection, nil
+}
+
+func (collector *IGTraceContainerCollector) GetTracerData(tracerName string) map[string]string {
+	events, _ := collector.data.Load(tracerName)
+	return events.(map[string]string)
+}

--- a/pkg/collector/inspektor_trace_tcp_collector_linux.go
+++ b/pkg/collector/inspektor_trace_tcp_collector_linux.go
@@ -2,28 +2,23 @@ package collector
 
 import (
 	"fmt"
-	"log"
-	"strings"
-	"sync"
-
+	"github.com/Azure/aks-periscope/pkg/collector/gadgets"
 	"github.com/Azure/aks-periscope/pkg/interfaces"
 	"github.com/Azure/aks-periscope/pkg/utils"
-	"github.com/cilium/ebpf/rlimit"
-
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/trace"
 	tcptracer "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcp/tracer"
 	tcptypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcp/types"
 	standardtracer "github.com/inspektor-gadget/inspektor-gadget/pkg/standardgadgets/trace/tcp"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+	"log"
 )
 
 // InspektorGadgetTCPTraceCollector defines a InspektorGadget Trace TCP Collector struct
 type InspektorGadgetTCPTraceCollector struct {
-	data                       map[string]string
-	runtimeInfo                *utils.RuntimeInfo
-	waiter                     func()
-	containerCollectionOptions []containercollection.ContainerCollectionOption
+	runtimeInfo          *utils.RuntimeInfo
+	igContainerCollector *gadgets.IGTraceContainerCollector
+	waiter               func()
 }
 
 // CheckSupported implements the interface method
@@ -40,70 +35,33 @@ func NewInspektorGadgetTCPTraceCollector(
 	containerCollectionOptions []containercollection.ContainerCollectionOption,
 ) *InspektorGadgetTCPTraceCollector {
 	return &InspektorGadgetTCPTraceCollector{
-		data:                       make(map[string]string),
-		runtimeInfo:                runtimeInfo,
-		waiter:                     waiter,
-		containerCollectionOptions: containerCollectionOptions,
+		runtimeInfo:          runtimeInfo,
+		waiter:               waiter,
+		igContainerCollector: gadgets.NewIGTraceContainerCollector(containerCollectionOptions),
 	}
 }
 
 func (collector *InspektorGadgetTCPTraceCollector) GetName() string {
-	return "inspektorgadget-tcptrace"
+	return "ig-tcptrace"
 }
 
 // Collect implements the interface method
 func (collector *InspektorGadgetTCPTraceCollector) Collect() error {
-	// From https://www.inspektor-gadget.io/blog/2022/09/using-inspektor-gadget-from-golang-applications/
-	// In some kernel versions it's needed to bump the rlimits to
-	// use run BPF programs.
-	if err := rlimit.RemoveMemlock(); err != nil {
-		return fmt.Errorf("failed to remove memlock: %w", err)
-	}
-
-	// We want to trace DNS queries from all pods running on the node, not just the current process.
-	// To do this we need to make use of a ContainerCollection, which can be initially populated
-	// with all the pod processes, and dynamically updated as pods are created and deleted.
-	containerEventCallback := func(event containercollection.PubSubEvent) {
-		// This doesn't *do* anything, but there will be runtime errors if we don't supply a callback.
-		switch event.Type {
-		case containercollection.EventTypeAddContainer:
-			log.Printf("Container added: %q pid %d\n", event.Container.Name, event.Container.Pid)
-		case containercollection.EventTypeRemoveContainer:
-			log.Printf("Container removed: %q pid %d\n", event.Container.Name, event.Container.Pid)
-		}
-	}
-
-	// Use the supplied container collection options, but prepend the container event callback.
-	// The options are all functions that are executed when the container collection is initialized.
-	opts := append(
-		[]containercollection.ContainerCollectionOption{containercollection.WithPubSub(containerEventCallback)},
-		collector.containerCollectionOptions...,
-	)
-
-	// Initialize the container collection
-	containerCollection := &containercollection.ContainerCollection{}
-	if err := containerCollection.Initialize(opts...); err != nil {
+	containerCollection, err := collector.igContainerCollector.InitContainerCollection()
+	if err != nil {
 		return fmt.Errorf("failed to initialize container collection: %w", err)
 	}
 	defer containerCollection.Close()
 
-	// Build up a collection of DNS query events, with a mutex to protect against concurrent access.
-	var mu sync.Mutex
-	events := []string{}
-
 	tcpEventCallback := func(event tcptypes.Event) {
-		eventString := eventtypes.EventString(event)
+		collector.igContainerCollector.PublishEvent(collector.GetName(), nil, eventtypes.EventString(event))
 
-		mu.Lock()
-		defer mu.Unlock()
-		events = append(events, eventString)
 	}
 
 	traceConfig := &tcptracer.Config{}
-	enricher := containerCollection
 
 	var tracer trace.Tracer
-	tracer, err := tcptracer.NewTracer(traceConfig, enricher, tcpEventCallback)
+	tracer, err = tcptracer.NewTracer(traceConfig, containerCollection, tcpEventCallback)
 	if err != nil {
 		log.Printf("Failed to create core tracer, falling back to standard one: %v", err)
 		tracer, err = standardtracer.NewTracer(traceConfig, tcpEventCallback)
@@ -113,21 +71,12 @@ func (collector *InspektorGadgetTCPTraceCollector) Collect() error {
 	}
 	defer tracer.Stop()
 
-	// The trace is now running. Run whatever function our consumer has supplied before storing the
-	// collected data.
 	collector.waiter()
-
-	// Store the collected data.
-	func() {
-		mu.Lock()
-		defer mu.Unlock()
-		collector.data["tcptracer"] = strings.Join(events, "\n")
-	}()
 
 	return nil
 }
 
 // GetData implements the interface method
 func (collector *InspektorGadgetTCPTraceCollector) GetData() map[string]interfaces.DataValue {
-	return utils.ToDataValueMap(collector.data)
+	return utils.ToDataValueMap(collector.igContainerCollector.GetTracerData(collector.GetName()))
 }


### PR DESCRIPTION
initial attempt to extract the common parts out. i think it might even work

it also makes me think that we can instead revert the logic of waiter() so that the tracers can initiate shutdown signal if _enough_ logs are collected